### PR TITLE
optionally use custom function for logFormat

### DIFF
--- a/cwlogs.js
+++ b/cwlogs.js
@@ -51,9 +51,15 @@ module.exports = class CwLogs {
 
           let logFunction = (message, timestamp) => console.log(timestamp, message);
           if (this.options.logFormat && this.options.logFormat !== 'default') {
-            try {
-              logFunction = require(path.join(__dirname, 'log-formats', `${this.options.logFormat}.js`));
-            } catch(err) {}
+
+            if (typeof(logFunction) == "function") {
+              logFunction = this.options.logFormat;
+            } else {
+              try {
+                logFunction = require(path.join(__dirname, 'log-formats', `${this.options.logFormat}.js`));
+              } catch(err) {}
+            }
+            
           }
 
           this.lastLogTime = events[events.length - 1].timestamp + 1;


### PR DESCRIPTION
The documentation states:

```
You can also pass a function(timestamp, message, event)) if you want to customize the format of your logs.
```

However, I could not see how that worked with the current code.  I added a function check for assigning the logFunction